### PR TITLE
Remove errant handling of files interface

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,10 +86,6 @@ export function determineFieldType(field: any): string {
 			return `${translationType}[] | null`;
 		}
 	}
-	// Handle files interface
-	if (field.meta?.special?.includes('files')) {
-		return 'DirectusFile[] | string[] | null';
-	}
 
 	if (field.relation?.collection) {
 		const relatedTypeName = pascalCase(singularize(field.relation.collection));


### PR DESCRIPTION
When using the files interface, Directus creates a junction object between the collection the field is on and the DirectusFiles collection. The regular handling generates the right type for the junction object -- this override does not seem to be correct in any of my testing.

Closes #11 