### PR TITLE
Support select-multiple-checkbox

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,13 @@
 import { isSEOField, seoTypeName } from './extensions/seo-plugin';
 
-export const interfacesWithChoices = [
-	'select-dropdown',
+export const interfacesWithSingleSelect = ['select-dropdown', 'select-radio'];
+export const interfacesWithMultiSelect = [
 	'select-multiple',
 	'select-multiple-dropdown',
-	'select-radio',
+	'select-multiple-checkbox',
 ];
+
+export const interfacesWithChoices = [...interfacesWithSingleSelect, ...interfacesWithMultiSelect];
 
 export function pascalCase(value: string): string {
 	return value
@@ -121,7 +123,7 @@ export function determineFieldType(field: any): string {
 
 		const unionOfChoices = uniqueChoices.join(' | ');
 
-		if (['select-multiple', 'select-multiple-dropdown'].includes(field.meta.interface)) {
+		if (interfacesWithMultiSelect.includes(field.meta.interface)) {
 			return `Array<${unionOfChoices}>`;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/bryantgillespie/directus-sdk-typegen/issues/22

I tried to keep the changes to a minimum but the inline array with 3 long names got a bit unwieldy and it party duplicated the `interfacesWithChoices` array. 

Any feedback is welcome. 

Running this version on my schema the particular field changed from:
``` typescript
collections: 'actions' | 'events';
```
into:
``` typescript
collections: Array<'actions' | 'events'>;
```